### PR TITLE
Accessor overwrite warnings no longer print if functions are identical

### DIFF
--- a/src/accessors.js
+++ b/src/accessors.js
@@ -85,7 +85,7 @@ function accessor_build(obj, p) {
 
 		// We can take an accessor function, a boolean, or a string
 		if( typeof value === 'function' ) {
-			if(p.sum) console.warn('SUM aggregation is being overwritten by AVG aggregation');
+			if(p.sum && p.sum !== value) console.warn('SUM aggregation is being overwritten by AVG aggregation');
 			p.sum = value;
 			p.avg = true;
 			p.count = 'count';
@@ -125,7 +125,7 @@ function accessor_build(obj, p) {
 		value = accessorifyNumeric(value);
 
 		if(typeof value === 'function') {
-			if(p.valueList) console.warn('VALUELIST accessor is being overwritten by median aggregation');
+			if(p.valueList && p.valueList !== value) console.warn('VALUELIST accessor is being overwritten by median aggregation');
 			p.valueList = value;
 		}
 		p.median = value;
@@ -138,7 +138,7 @@ function accessor_build(obj, p) {
 		value = accessorifyNumeric(value);
 
 		if(typeof value === 'function') {
-			if(p.valueList) console.warn('VALUELIST accessor is being overwritten by median aggregation');
+			if(p.valueList && p.valueList !== value) console.warn('VALUELIST accessor is being overwritten by min aggregation');
 			p.valueList = value;
 		}
 		p.min = value;
@@ -151,7 +151,7 @@ function accessor_build(obj, p) {
 		value = accessorifyNumeric(value);
 
 		if(typeof value === 'function') {
-			if(p.valueList) console.warn('VALUELIST accessor is being overwritten by median aggregation');
+			if(p.valueList && p.valueList !== value) console.warn('VALUELIST accessor is being overwritten by max aggregation');
 			p.valueList = value;
 		}
 		p.max = value;
@@ -164,7 +164,7 @@ function accessor_build(obj, p) {
 		value = accessorify(value);
 
 		if( typeof value === 'function' ) {
-			if(p.sum) console.warn('EXCEPTION accessor is being overwritten by exception count aggregation');
+			if(p.exceptionAccessor && p.exceptionAccessor !== value) console.warn('EXCEPTION accessor is being overwritten by exception count aggregation');
 			p.exceptionAccessor = value;
 			p.exceptionCount = true;
 		} else {


### PR DESCRIPTION
Added an identity check before printing accessor overwrite warnings, since replacing a function with the exact same function is not really an overwrite. ;)

The short "why": I ran into a case where I couldn't easily switch to "boolean mode" when defining `min`, `max`, etc. since I'm constructing a reducer dynamically based on some other stuff. My attempts to circumvent the warnings got pretty ugly, and I figure an upstream PR wouldn't hurt.

While there, I also fixed a couple of items that seemed incorrect ('median' instead of 'min'/'max' in warning text and the wrong variable checked for exceptionCount). My apologies for not including them in a separate commit.