### PR TITLE
Update crossfilter dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "dependencies": {
-    "crossfilter2": "^2.0.0"
+    "crossfilter2": "^2.0.0-alpha.4"
   },
   "devDependencies": {
     "browserify": "^8.1.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "dependencies": {
-    "crossfilter2": "^1.4.0-alpha.05"
+    "crossfilter2": "^2.0.0"
   },
   "devDependencies": {
     "browserify": "^8.1.1",


### PR DESCRIPTION
Upgrade to use the newest version of crossfilter.

Side note: webpack loaders seemed to have issues including 1.4.0, not sure why. 